### PR TITLE
Add Architec.ton wallet

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -322,5 +322,19 @@
       }
     ],
     "platforms": ["chrome"]
+  },
+  {
+    "app_name": "architec.ton",
+    "name": "Architec.ton",
+    "image": "https://raw.githubusercontent.com/Architec-Ton/wallet-tma/refs/heads/dev/public/images/arcwallet_logo.png",
+    "about_url": "https://architecton.tech",
+    "universal_url": "https://t.me/architec_ton_bot/wallet",
+    "bridge": [
+      {
+        "type": "sse",
+        "url": "https://tonconnect.architecton.site/bridge"
+      }
+    ],
+    "platforms": ["ios", "android", "macos", "windows", "linux"]
   }
 ]


### PR DESCRIPTION
# Add Architec.ton wallet

## Supports
- [x]  HTTP bridge as a wallet app for TG

## Supported features
- [x]  ton_proof
- [x]  SendTransaction

## Test
https://app1.architecton.site/wallet

## Integrator contacts
telegram: @stanta 
telegram: @egorkqq 
email: st@architecton.tech
email: egor@architecton.tech
